### PR TITLE
Fix uninitialized state variables

### DIFF
--- a/platoon_ws/src/longitudinal_control/src/longitudinal_control.cpp
+++ b/platoon_ws/src/longitudinal_control/src/longitudinal_control.cpp
@@ -7,13 +7,19 @@ namespace longitudinal_control
 LongitudinalController::LongitudinalController(const rclcpp::NodeOptions & options)
 : rclcpp::Node("longitudinal_controller", options),
   lead_x_(0.0),
+  lead_y_(0.0),
+  prev_lead_x_(0.0),
+  prev_lead_y_(0.0),
   ego_x_(0.0),
   current_gap_(0.0),
   prev_gap_(0.0),
   gap_rate_(0.0),
   lead_velocity_(0.0),
   ego_velocity_(0.0),
-  prev_time_(this->get_clock()->now())
+  ref_velocity_(0.0),
+  prev_time_(this->get_clock()->now()),
+  truck_id_(0),
+  desired_velocity_(0.0)
 {
     this->declare_parameter("gap_kp", 0.8);
     this->declare_parameter("gap_kd", 0.4);


### PR DESCRIPTION
## Summary
- initialize all state variables in `LongitudinalController`

## Testing
- `pytest platoon_ws/src/lane_detection/test/test_flake8.py -q` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_6842b34ad56c832f8bb407c2b8678829