### PR TITLE
Fix throttle not reducing by scaling feedforward

### DIFF
--- a/platoon_ws/src/longitudinal_control/include/longitudinal_control/longitudinal_control.hpp
+++ b/platoon_ws/src/longitudinal_control/include/longitudinal_control/longitudinal_control.hpp
@@ -39,6 +39,7 @@ private:
   double vel_ki_;
   double k_aw_;
   double throttle_limit_;
+  double ff_gain_;
 
   // --- State variables ------------------------------------------------------
   double lead_x_;

--- a/platoon_ws/src/longitudinal_control/include/longitudinal_control/velocity_control.hpp
+++ b/platoon_ws/src/longitudinal_control/include/longitudinal_control/velocity_control.hpp
@@ -10,8 +10,10 @@ class VelocityController
 {
 public:
   VelocityController();
-  VelocityController(double kp, double ki, double aw_gain, double throttle_limit);
-  void param(double kp, double ki, double aw_gain, double throttle_limit);
+  VelocityController(double kp, double ki, double aw_gain,
+                     double throttle_limit, double ff_gain);
+  void param(double kp, double ki, double aw_gain,
+             double throttle_limit, double ff_gain);
   double update(double velocity_error, double dt);
   double update(double ref_vel, double meas_vel, double dt);
 
@@ -20,6 +22,7 @@ private:
   double ki_;
   double aw_gain_;
   double throttle_limit_;
+  double ff_gain_;
   double integral_;
 };
 

--- a/platoon_ws/src/longitudinal_control/launch/longitudinal_control_launch.py
+++ b/platoon_ws/src/longitudinal_control/launch/longitudinal_control_launch.py
@@ -21,6 +21,7 @@ def generate_nodes(context, *, num_trucks):
                 {'vel_ki': 2.0},
                 {'k_aw': 1.0},
                 {'throttle_limit': 0.8},
+                {'ff_gain': 0.05},
                 {'truck_id': i},
                 {'desired_velocity': 10.0}
             ]

--- a/platoon_ws/src/longitudinal_control/src/longitudinal_control.cpp
+++ b/platoon_ws/src/longitudinal_control/src/longitudinal_control.cpp
@@ -26,10 +26,12 @@ LongitudinalController::LongitudinalController(const rclcpp::NodeOptions & optio
     this->declare_parameter("vel_ki", 2.0);
     this->declare_parameter("k_aw", 1e-4);
     this->declare_parameter("throttle_limit", 1.0);
+    this->declare_parameter("ff_gain", 0.05);
     vel_kp_ = this->get_parameter("vel_kp").as_double();
     vel_ki_ = this->get_parameter("vel_ki").as_double();
     k_aw_ = this->get_parameter("k_aw").as_double();
     throttle_limit_ = this->get_parameter("throttle_limit").as_double();
+    ff_gain_ = this->get_parameter("ff_gain").as_double();
 
     this->declare_parameter("truck_id", 0);
     this->declare_parameter("desired_velocity", 36.0);
@@ -37,7 +39,7 @@ LongitudinalController::LongitudinalController(const rclcpp::NodeOptions & optio
     desired_velocity_ = this->get_parameter("desired_velocity").as_double();
 
     gap_ctrl_.param(gap_kp_, gap_kd_, desired_gap_);
-    vel_ctrl_.param(vel_kp_, vel_ki_, k_aw_, throttle_limit_);
+    vel_ctrl_.param(vel_kp_, vel_ki_, k_aw_, throttle_limit_, ff_gain_);
 
     // Subscriptions -----------------------------------------------------------
     if (truck_id_ != 0)

--- a/platoon_ws/src/longitudinal_control/src/velocity_control.cpp
+++ b/platoon_ws/src/longitudinal_control/src/velocity_control.cpp
@@ -3,19 +3,24 @@
 namespace longitudinal_control
 {
 
-VelocityController::VelocityController() {}
+VelocityController::VelocityController()
+: kp_(0.0), ki_(0.0), aw_gain_(0.0),
+  throttle_limit_(1.0), ff_gain_(0.0), integral_(0.0) {}
 
 VelocityController::VelocityController(double kp, double ki,
-                                       double aw_gain, double throttle_limit)
+                                       double aw_gain,
+                                       double throttle_limit, double ff_gain)
 : kp_(kp), ki_(ki), aw_gain_(aw_gain),
-  throttle_limit_(throttle_limit), integral_(0.0) {}
+  throttle_limit_(throttle_limit), ff_gain_(ff_gain), integral_(0.0) {}
 
-void VelocityController::param(double kp, double ki, double aw_gain, double throttle_limit)
+void VelocityController::param(double kp, double ki, double aw_gain,
+                               double throttle_limit, double ff_gain)
 {
     kp_ = kp;
     ki_ = ki;
     aw_gain_ = aw_gain;
     throttle_limit_ = throttle_limit;
+    ff_gain_ = ff_gain;
 }
 
 double VelocityController::update(double velocity_error, double dt)
@@ -40,7 +45,7 @@ double VelocityController::update(double ref_vel,
                                   double dt)
 {
   // --- Feed-Forward --------------------------------------------------
-  double u_ff = 1.0 * ref_vel;               // 가장 단순한 형태 (선형 비례)
+  double u_ff = ff_gain_ * ref_vel;               // scaled feed-forward
 
   // --- PI ------------------------------------------------------------
   double vel_error = ref_vel - meas_vel;


### PR DESCRIPTION
## Summary
- add a feed‑forward gain parameter to velocity controller
- expose this parameter in longitudinal controller and launch file
- scale feed‑forward contribution so throttle command can decrease when the gap is small

## Testing
- `colcon build --cmake-args -DBUILD_TESTING=OFF` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b4897e50832fb0aeabd66bea2834