### PR TITLE
Implement emergency stop trigger in circle tracking

### DIFF
--- a/platoon_ws/src/truck_detection/include/truck_detection/circle_tracking.hpp
+++ b/platoon_ws/src/truck_detection/include/truck_detection/circle_tracking.hpp
@@ -3,6 +3,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <std_msgs/msg/bool.hpp>
 
 #include "obstacle_detector/msg/obstacles.hpp"
 #include "obstacle_detector/msg/circle_obstacle.hpp"
@@ -20,9 +21,11 @@ private:
   // ROS I/O
   rclcpp::Subscription<obstacle_detector::msg::Obstacles>::SharedPtr sub_;
   rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr pub_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr emergency_pub_;
 
   // Parameters
   int truck_id_;
+  double stop_distance_;
   
   void obstaclesCallback(const obstacle_detector::msg::Obstacles::ConstSharedPtr & msg);
   void updateParameters();


### PR DESCRIPTION
## Summary
- add emergency stop publisher and parameter
- publish `/emergency_stop` when truck0's detected front truck is within `stop_distance`

## Testing
- `colcon build --packages-select truck_detection` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495a3c8194832fa1f4ba67251fa386