### PR TITLE
Move emergency stop logic

### DIFF
--- a/platoon_ws/src/longitudinal_control/include/longitudinal_control/longitudinal_control.hpp
+++ b/platoon_ws/src/longitudinal_control/include/longitudinal_control/longitudinal_control.hpp
@@ -26,7 +26,6 @@ private:
   void egoVelocityCallback(const std_msgs::msg::Float32::SharedPtr msg);
   void egoPoseCallback(const geometry_msgs::msg::Pose::SharedPtr msg);
   void cameraOnCallback(const std_msgs::msg::Bool::SharedPtr msg);
-  void emerStopCallback(const std_msgs::msg::Bool::SharedPtr msg);
   void timerCallback();
 
   // --- Controllers ----------------------------------------------------------
@@ -44,6 +43,7 @@ private:
   double ff_gain_;
 
   double dec_rate_;
+  double braking_decel_;
 
   // --- State variables ------------------------------------------------------
   double lead_x_;
@@ -66,11 +66,11 @@ private:
   rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_ego_vel_;
   rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_ref_vel_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_camera_on_;
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_emer_stop_;
 
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_throttle_;
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_ref_vel_;
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_desired_gap_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr pub_emer_stop_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr parameter_callback_handle_;

--- a/platoon_ws/src/truck_detection/CMakeLists.txt
+++ b/platoon_ws/src/truck_detection/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
@@ -38,7 +37,6 @@ add_library(circle_tracking
 
 ament_target_dependencies(circle_tracking
   rclcpp
-  std_msgs
   geometry_msgs
   obstacle_detector
 )

--- a/platoon_ws/src/truck_detection/include/truck_detection/circle_tracking.hpp
+++ b/platoon_ws/src/truck_detection/include/truck_detection/circle_tracking.hpp
@@ -3,8 +3,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/pose.hpp>
-#include <std_msgs/msg/bool.hpp>
-#include <std_msgs/msg/float32.hpp>
 
 #include "obstacle_detector/msg/obstacles.hpp"
 #include "obstacle_detector/msg/circle_obstacle.hpp"
@@ -21,18 +19,12 @@ public:
 private:
   // ROS I/O
   rclcpp::Subscription<obstacle_detector::msg::Obstacles>::SharedPtr sub_;
-  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr vel_sub_;
   rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr pub_;
-  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr emergency_pub_;
 
   // Parameters
   int truck_id_;
-  double braking_decel_;
-  double ego_velocity_;
-  bool emergency_stop_;
   
   void obstaclesCallback(const obstacle_detector::msg::Obstacles::ConstSharedPtr & msg);
-  void velocityCallback(const std_msgs::msg::Float32::SharedPtr msg);
   void updateParameters();
 };
 

--- a/platoon_ws/src/truck_detection/package.xml
+++ b/platoon_ws/src/truck_detection/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>visualization_msgs</depend>

--- a/platoon_ws/src/truck_detection/src/circle_tracking.cpp
+++ b/platoon_ws/src/truck_detection/src/circle_tracking.cpp
@@ -1,17 +1,12 @@
 #include "truck_detection/circle_tracking.hpp"
-#include <std_msgs/msg/bool.hpp>
 
 namespace truck_detection
 {
 
 CircleTracking::CircleTracking(const rclcpp::NodeOptions & options)
-: rclcpp::Node("circle_tracking", options),
-  braking_decel_(9.0),
-  ego_velocity_(0.0),
-  emergency_stop_(false)
+: rclcpp::Node("circle_tracking", options)
 {
   this->declare_parameter("truck_id", 0);
-  this->declare_parameter("braking_decel", 6.0);
   updateParameters();
 
   const std::string in_topic = "/truck" + std::to_string(truck_id_) + "/raw_obstacles";
@@ -19,21 +14,14 @@ CircleTracking::CircleTracking(const rclcpp::NodeOptions & options)
       in_topic, rclcpp::SensorDataQoS(),
       std::bind(&CircleTracking::obstaclesCallback, this, std::placeholders::_1));
 
-  const std::string vel_topic = "/truck" + std::to_string(truck_id_) + "/velocity";
-  vel_sub_ = this->create_subscription<std_msgs::msg::Float32>(
-      vel_topic, 10,
-      std::bind(&CircleTracking::velocityCallback, this, std::placeholders::_1));
-
   const std::string out_topic = "/truck" + std::to_string(truck_id_) + "/front_truck_pose";
   pub_ = this->create_publisher<geometry_msgs::msg::Pose>(out_topic, 10);
 
-  emergency_pub_ = this->create_publisher<std_msgs::msg::Bool>("/emergency_stop", 10);
 }
 
 void CircleTracking::updateParameters()
 {
   truck_id_ = this->get_parameter("truck_id").as_int();
-  braking_decel_ = this->get_parameter("braking_decel").as_double();
 }
 
 void CircleTracking::obstaclesCallback(const obstacle_detector::msg::Obstacles::ConstSharedPtr & msg)
@@ -80,22 +68,7 @@ void CircleTracking::obstaclesCallback(const obstacle_detector::msg::Obstacles::
               "Closest circle at (%.2f, %.2f) — distance %.2f m",
               x, y, distance);
 
-  if (truck_id_ == 0)
-  {
-    const double safe_distance = (ego_velocity_ * ego_velocity_) /
-                               (2.0 * std::max(braking_decel_, 0.1));
-    emergency_stop_ = distance <= safe_distance;
-    RCLCPP_INFO(this->get_logger(),
-                "safe_distance %.2f — emergency %d",
-                safe_distance, emergency_stop_);
 
-    if (emergency_stop_)
-    {
-      std_msgs::msg::Bool stop_msg;
-      stop_msg.data = true;
-      emergency_pub_->publish(stop_msg);
-    }
-  }
 
   // 퍼블리시할 Pose 메시지 작성
   pose_msg.position.x = x;
@@ -104,11 +77,6 @@ void CircleTracking::obstaclesCallback(const obstacle_detector::msg::Obstacles::
   pose_msg.orientation.w = 1.0;  // 단순 2D 위치이므로 단위 quaternion
 
   pub_->publish(pose_msg);
-}
-
-void CircleTracking::velocityCallback(const std_msgs::msg::Float32::SharedPtr msg)
-{
-  ego_velocity_ = msg->data;
 }
 
 }


### PR DESCRIPTION
## Summary
- move emergency stop logic from truck detection to longitudinal control
- drop emergency dependencies from truck_detection
- publish emergency stop in longitudinal controller

## Testing
- `colcon build --packages-select longitudinal_control truck_detection` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685038df22fc832f8139650ee1598b60